### PR TITLE
Remove unnecessary dependency on kardianos/osext

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/mouuff/go-rocket-update
 
 go 1.12
-
-require github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uiaSepXwyf3o52HaUYcV+Tu66S3F5GA=
-github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=

--- a/internal/fileio/fileio.go
+++ b/internal/fileio/fileio.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-
-	"github.com/kardianos/osext"
 )
 
 // CopyFile copies file contents from file source to file destination
@@ -80,5 +78,5 @@ func TempDir() (string, error) {
 
 // GetExecutable get the path to the current executable
 func GetExecutable() (string, error) {
-	return osext.Executable()
+	return os.Executable()
 }


### PR DESCRIPTION
Go std lib provides a cross-platform implementation for `os.Executable` since 1.8. [kardianos/osext](https://github.com/kardianos/osext) also uses the std lib implementation for Go >= 1.8. If we don't need Go < 1.8 support, we can simply use `os.Executable`.